### PR TITLE
Extract image and static paths as settings so users can supply their own emojis.

### DIFF
--- a/emoji/models.py
+++ b/emoji/models.py
@@ -60,9 +60,8 @@ class Emoji(object):
     '/static/emoji/dog.png'
 
     """
-    _static_path = 'emoji/img'
-    _image_path = os.path.join(os.path.dirname(__file__),
-                               'static', 'emoji', 'img')
+    _static_path = settings.EMOJI_STATIC_PATH
+    _image_path = settings.EMOJI_IMAGE_PATH
     _instance = None
     _pattern = re.compile(r':([a-z0-9\+\-_]+):', re.I)
     _files = []

--- a/emoji/settings.py
+++ b/emoji/settings.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+import os
 
 # The exact tag that is being used for replacing images and the values
 # being passed in through `str#format`.
@@ -9,3 +10,9 @@ EMOJI_IMG_TAG = getattr(settings, 'EMOJI_IMG_TAG', (
 EMOJI_ALT_AS_UNICODE = getattr(settings, 'EMOJI_ALT_AS_UNICODE', True)
 EMOJI_REPLACE_HTML_ENTITIES = getattr(settings, 'EMOJI_REPLACE_HTML_ENTITIES',
                                       True)
+
+EMOJI_IMAGE_PATH = getattr(settings, 'EMOJI_IMAGE_PATH',
+        os.path.join(os.path.dirname(__file__), 'static', 'emoji', 'img'))
+
+EMOJI_STATIC_PATH = getattr(settings, 'EMOJI_STATIC_PATH', 'emoji/img')
+


### PR DESCRIPTION
This allows users to specify the emoji static and image paths so they can supply their own emoji images in their django app or elsewhere, supplying different or additional emojis than those included with this one.